### PR TITLE
fix: cache results in db as json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
             <artifactId>sfn</artifactId>
         </dependency>
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-spring</artifactId>
         </dependency>
@@ -150,6 +154,11 @@
             <version>2.2.0</version>
         </dependency>
         <dependency>
+            <groupId>com.opencsv</groupId>
+            <artifactId>opencsv</artifactId>
+            <version>5.9</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
@@ -159,6 +168,12 @@
             <artifactId>curator-client</artifactId>
             <version>5.2.0</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/mytiki/account/features/latest/ocean/OceanService.java
+++ b/src/main/java/com/mytiki/account/features/latest/ocean/OceanService.java
@@ -10,25 +10,36 @@ import com.amazonaws.xray.spring.aop.XRayEnabled;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mytiki.account.utilities.builder.ErrorBuilder;
+import com.mytiki.account.utilities.error.ApiException;
+import com.opencsv.CSVReader;
+import com.opencsv.exceptions.CsvException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Uri;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.sfn.SfnClient;
 import software.amazon.awssdk.services.sfn.model.*;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @XRayEnabled
 public class OceanService {
     protected static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-    private final SfnClient client;
+    private final SfnClient sfnClient;
+    private final S3Client s3Client;
     private final String arn;
     private final ObjectMapper mapper;
     private final OceanRepository repository;
@@ -41,14 +52,27 @@ public class OceanService {
                                 .addExecutionInterceptor(new TracingInterceptor())
                                 .build())
                         .build(),
+                S3Client.builder()
+                        .region(Region.of(region))
+                        .overrideConfiguration(ClientOverrideConfiguration
+                                .builder()
+                                .addExecutionInterceptor(new TracingInterceptor())
+                                .build())
+                        .build(),
                 arn, mapper, repository);
     }
 
-    public OceanService(SfnClient client, String arn, ObjectMapper mapper, OceanRepository repository) {
+    public OceanService(
+            SfnClient sfnClient,
+            S3Client s3Client,
+            String arn,
+            ObjectMapper mapper,
+            OceanRepository repository) {
         this.arn = arn;
         this.mapper = mapper;
         this.repository = repository;
-        this.client = client;
+        this.sfnClient = sfnClient;
+        this.s3Client = s3Client;
     }
 
     public OceanDO query(OceanType type, String query) {
@@ -72,12 +96,29 @@ public class OceanService {
             OceanDO ocean = found.get();
             ocean.setStatus(OceanStatus.SUCCESS);
             ocean.setResultUri(req.getResultUri());
-            //go get the result from s3 and update the DB.
+            try {
+                List<String[]> res = fetch(req.getResultUri());
+                ocean.setResult(mapper.writeValueAsString(res));
+            }catch (ApiException | JsonProcessingException e) {
+                logger.warn("Failed to retrieve results. Skipping", e);
+            }
             ocean.setModified(ZonedDateTime.now());
             repository.save(ocean);
         } else {
             logger.warn("Skipping. Invalid request id: " + req.getRequestId());
         }
+    }
+
+    public OceanDO get(String requestId) {
+        Optional<OceanDO> found = repository.findByRequestId(UUID.fromString(requestId));
+        if(found.isPresent()) {
+            if(found.get().getStatus() == OceanStatus.PENDING){
+                OceanDO update = found.get();
+                update.setStatus(status(update.getExecutionArn()));
+                update.setModified(ZonedDateTime.now());
+                return repository.save(update);
+            }else return found.get();
+        }else return null;
     }
 
     private String execute(UUID request, String query) {
@@ -92,7 +133,7 @@ public class OceanService {
                     .stateMachineArn(arn)
                     .name(requestId)
                     .build();
-            StartExecutionResponse rsp = client.startExecution(executionRequest);
+            StartExecutionResponse rsp = sfnClient.startExecution(executionRequest);
             return rsp.executionArn();
         } catch (JsonProcessingException | SfnException e) {
             throw new ErrorBuilder(HttpStatus.EXPECTATION_FAILED)
@@ -107,7 +148,7 @@ public class OceanService {
             DescribeExecutionRequest executionRequest = DescribeExecutionRequest.builder()
                 .executionArn(executionArn)
                 .build();
-            DescribeExecutionResponse response = client.describeExecution(executionRequest);
+            DescribeExecutionResponse response = sfnClient.describeExecution(executionRequest);
             return switch(response.status()){
                 case SUCCEEDED -> OceanStatus.SUCCESS;
                 case RUNNING, PENDING_REDRIVE -> OceanStatus.PENDING;
@@ -116,6 +157,28 @@ public class OceanService {
         } catch (SfnException e) {
             throw new ErrorBuilder(HttpStatus.EXPECTATION_FAILED)
                     .message("Failed to retrieve query status")
+                    .cause(e)
+                    .exception();
+        }
+    }
+
+    private List<String[]> fetch(String s3Uri) {
+        try {
+            S3Uri uri = s3Client.utilities().parseUri(new URI(s3Uri));
+            if(uri.bucket().isEmpty() || uri.key().isEmpty())
+                throw new URISyntaxException(s3Uri, "Bucket and/or Key missing");
+
+            GetObjectRequest objectRequest = GetObjectRequest.builder()
+                    .bucket(uri.bucket().get())
+                    .key(uri.key().get())
+                    .build();
+            ResponseBytes<GetObjectResponse> objectBytes = s3Client.getObjectAsBytes(objectRequest);
+            CSVReader reader = new CSVReader(new InputStreamReader(objectBytes.asInputStream()));
+            return reader.readAll();
+        }catch (URISyntaxException | IOException | CsvException e){
+            throw new ErrorBuilder(HttpStatus.BAD_REQUEST)
+                    .message("Failed to fetch URI")
+                    .properties("URI", s3Uri)
                     .cause(e)
                     .exception();
         }


### PR DESCRIPTION
# Issues Addressed
Completes the round-trip from the async query by fetching the results from s3 and saving them as json in the db. We can use these results to return the stats for estimate, create, and update queries. queries without results need additional testing as they may get stuck in "pending" state. 


