### PR TITLE
fix: add same blind delete as api key

### DIFF
--- a/src/main/java/com/mytiki/account/features/latest/refresh/RefreshRepository.java
+++ b/src/main/java/com/mytiki/account/features/latest/refresh/RefreshRepository.java
@@ -6,7 +6,9 @@
 package com.mytiki.account.features.latest.refresh;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -17,6 +19,8 @@ import java.util.UUID;
 public interface RefreshRepository extends JpaRepository<RefreshDO, UUID> {
     Optional<RefreshDO> findByJti(UUID jti);
 
+    @Modifying
+    @Transactional
     void deleteByJti(UUID jti);
 
     List<RefreshDO> findAllByExpiresBefore(ZonedDateTime before);


### PR DESCRIPTION
# Issues Addressed
resolves #341

## Additional Information
adds the same changes as implemented to allow api keys to be blindly revoked. should fix the refresh token revoke issue. 
